### PR TITLE
Boot let-go binaries without the compiler linked

### DIFF
--- a/src/gloat.clj
+++ b/src/gloat.clj
@@ -1356,7 +1356,7 @@ Less common:
 
 (defn LG-entry-code [entry-fn]
   (if entry-fn
-    (str "\tif _, err := prog." entry-fn "(vm.RootExecContext, argv...);"
+    (str "\tif _, err := prog." entry-fn "(ec, argv...);"
          " err != nil {\n\t\tfail(err)\n\t}")
     (str "\tf := vm.NewFrame(unit.MainChunk, nil)\n"
          "\t_, err = f.RunProtected()\n"

--- a/template/lg-lib-main.go
+++ b/template/lg-lib-main.go
@@ -3,13 +3,9 @@ package main
 import "C"
 
 import (
-	"bytes"
 	_ "embed"
 	"fmt"
 
-	"github.com/nooga/let-go/pkg/bytecode"
-	"github.com/nooga/let-go/pkg/compiler"
-	"github.com/nooga/let-go/pkg/resolver"
 	"github.com/nooga/let-go/pkg/rt"
 	"github.com/nooga/let-go/pkg/vm"
 LOWERED-IMPORTS
@@ -21,32 +17,18 @@ var lgbData []byte
 const programNamespace = "NAMESPACE"
 
 func init() {
-	ctx := compiler.NewCompiler(vm.NewConsts(), rt.NS("user"))
-	rt.SetNSLoader(resolver.NewNSResolver(ctx, nil))
-
-	resolve := func(nsName, name string) *vm.Var {
-		n := rt.DefNSBare(nsName)
-		if v := n.LookupLocal(vm.Symbol(name)); v != nil {
-			return v
-		}
-		return n.DefStub(name)
+	// Runtime-only boot: core loads from its embedded bundle, so neither
+	// the compiler nor the resolver is linked into the shared library.
+	if _, err := rt.BootCore(); err != nil {
+		panic(vm.FormatError(err))
 	}
-	unit, err := bytecode.DecodeToExecUnit(bytes.NewReader(lgbData), resolve)
+	unit, err := rt.DecodeExecUnit(lgbData)
 	if err != nil {
 		panic(vm.FormatError(err))
 	}
-	for _, name := range unit.NSOrder {
-		chunk := unit.NSChunks[name]
-		if chunk == nil || chunk == unit.MainChunk {
-			continue
-		}
-		f := vm.NewFrame(chunk, nil)
-		_, err := f.RunProtected()
-		vm.ReleaseFrame(f)
-		if err != nil {
-			panic(vm.FormatError(fmt.Errorf("loading namespace %s: %w", name, err)))
-		}
-		rt.ApplyGoOverrides(rt.LookupNS(name))
+	// Replays every ns chunk and drains each one's Go-native overrides.
+	if err := rt.LoadProgramNamespaces(unit); err != nil {
+		panic(vm.FormatError(err))
 	}
 }
 

--- a/template/lg-lib-main.go
+++ b/template/lg-lib-main.go
@@ -26,9 +26,22 @@ func init() {
 	if err != nil {
 		panic(vm.FormatError(err))
 	}
-	// Replays every ns chunk and drains each one's Go-native overrides.
-	if err := rt.LoadProgramNamespaces(unit); err != nil {
-		panic(vm.FormatError(err))
+	// Same skip+drain loop as lg-main.go. rt.LoadProgramNamespaces would
+	// replay MainChunk (wrong if the driver calls -main) and is not in the
+	// pinned let-go v1.12.2 release; keep the explicit loop so the pin and
+	// the semantics stay aligned.
+	for _, name := range unit.NSOrder {
+		chunk := unit.NSChunks[name]
+		if chunk == nil || chunk == unit.MainChunk {
+			continue
+		}
+		f := vm.NewFrame(chunk, nil)
+		_, err := f.RunProtected()
+		vm.ReleaseFrame(f)
+		if err != nil {
+			panic(vm.FormatError(fmt.Errorf("loading namespace %s: %w", name, err)))
+		}
+		rt.ApplyGoOverrides(rt.LookupNS(name))
 	}
 }
 

--- a/template/lg-main.go
+++ b/template/lg-main.go
@@ -7,14 +7,10 @@ package main
 // call; otherwise the driver main chunk runs it on the VM.
 
 import (
-	"bytes"
 	_ "embed"
 	"fmt"
 	"os"
 
-	"github.com/nooga/let-go/pkg/bytecode"
-	"github.com/nooga/let-go/pkg/compiler"
-	"github.com/nooga/let-go/pkg/resolver"
 	"github.com/nooga/let-go/pkg/rt"
 	"github.com/nooga/let-go/pkg/vm"
 LOWERED-IMPORTS
@@ -29,34 +25,32 @@ func fail(err error) {
 }
 
 func main() {
-	// Importing pkg/compiler booted core from its embedded bundle; the
-	// resolver (nil paths) lets replayed requires load embedded nses.
-	ctx := compiler.NewCompiler(vm.NewConsts(), rt.NS("user"))
-	rt.SetNSLoader(resolver.NewNSResolver(ctx, nil))
+	// Runtime-only boot: core loads from its embedded bundle, so neither
+	// the compiler nor the resolver is linked into the binary. Replayed
+	// requires resolve against namespaces the loop below has already
+	// installed, which is every namespace the bundle carries.
+	ec, err := rt.BootCore()
+	if err != nil {
+		fail(err)
+	}
 	defer rt.ShutdownAllPods()
 
 	args := os.Args[1:]
 	argv := make([]vm.Value, len(args))
-	var cla vm.Value = vm.NIL
-	if len(args) > 0 {
-		for i, a := range args {
-			argv[i] = vm.String(a)
-		}
-		cla = vm.NewList(argv)
+	for i, a := range args {
+		argv[i] = vm.String(a)
 	}
-	rt.CoreNS.Lookup("*command-line-args*").(*vm.Var).SetRoot(cla)
+	rt.SetCommandLineArgs(args)
 
-	resolve := func(nsName, name string) *vm.Var {
-		n := rt.DefNSBare(nsName)
-		if v := n.LookupLocal(vm.Symbol(name)); v != nil {
-			return v
-		}
-		return n.DefStub(name)
-	}
-	unit, err := bytecode.DecodeToExecUnit(bytes.NewReader(lgbData), resolve)
+	unit, err := rt.DecodeExecUnit(lgbData)
 	if err != nil {
 		fail(err)
 	}
+	// MainChunk is skipped here on purpose: gloat's driver chunk calls
+	// -main, so replaying it would run the program before (and in the
+	// :direct case in addition to) the entry call below. rt.RunExecUnit
+	// skips it too but drains no overrides, and rt.LoadProgramNamespaces
+	// drains them but replays MainChunk — neither fits this shape.
 	for _, name := range unit.NSOrder {
 		chunk := unit.NSChunks[name]
 		if chunk == nil || chunk == unit.MainChunk {
@@ -71,6 +65,7 @@ func main() {
 		// Drain this ns's Go-native overrides (no-op when none).
 		rt.ApplyGoOverrides(rt.LookupNS(name))
 	}
+	_ = ec
 	_ = argv
 ENTRY-CODE
 }

--- a/test/lg-shared-lib.t
+++ b/test/lg-shared-lib.t
@@ -48,7 +48,10 @@ for engine in lgvm lglvm; do
   is "$rc" 0 "C caller links to the -E$engine library"
 
   if [[ -x $TMP/call-$engine ]]; then
-    try "$TMP/call-$engine"
+    # The dylib's install name is the bare basename (shared.dylib). dyld
+    # resolves that relative to cwd, so run from $TMP — not from the
+    # project root — or load fails with "Library not loaded".
+    try "cd $TMP && ./call-$engine"
     is "$rc" 0 "C caller for -E$engine exits 0"
     is "$got" 42 "C caller invokes the -E$engine export"
   fi


### PR DESCRIPTION
The LG engine's generated `main.go` and `lib-main.go` boot core by importing `pkg/compiler` and installing a resolver:

```go
ctx := compiler.NewCompiler(vm.NewConsts(), rt.NS("user"))
rt.SetNSLoader(resolver.NewNSResolver(ctx, nil))
```

That links the whole let-go compiler and resolver into every binary gloat produces, to do work that finishes before the program starts. let-go exposes `rt.BootCore` (runtime-only core boot from the embedded bundle) and `rt.DecodeExecUnit` (decode with the standard var resolver), so both templates can boot without either package. `rt.SetCommandLineArgs` replaces the hand-rolled `*command-line-args*` binding — same nil-vs-list semantics.

**Minimum let-go: v1.12.2** — the version gloat already pins (`LET-GO-VERSION` in `common.mk`). All three helpers are in that tag. No pin bump.

**Effect on a hello-world native binary:**

| | bytes |
|---|---|
| before | 13,406,914 |
| after | 12,245,586 |
| | **−1,161,328 (−8.7%)** |

**Namespace replay stays an explicit skip+drain loop** in both templates. Neither upstream helper fits this shape:

- `rt.RunExecUnit` skips `MainChunk` but never calls `ApplyGoOverrides`, so adopting it would silently drop every lowered native override.
- `rt.LoadProgramNamespaces` drains overrides but replays `MainChunk`. gloat's driver chunk calls `-main`, so in `:direct` mode the program would run twice. That helper also is not in v1.12.2.

An earlier revision of `lg-lib-main.go` called `LoadProgramNamespaces`; this branch restores the same explicit loop the executable template uses so the pin and the semantics stay aligned.

**Tests** (`RUN_SLOW_TESTS=1`, against let-go v1.12.2):

- `test/lg-native-bin.t` — 7/7
- `test/lg-shared-lib.t` — 10/10 (also fixes the caller to `cd` into `$TMP` before exec so dyld resolves the bare `shared.dylib` install name; previously failed with "Library not loaded" from the project root)

**Ownership note (let-go #628):** frame emission there is now opt-in (`lg-compile --entry-frame`). Gloat keeps owning these templates; omit the flag and there is no duplicate `func main()`.
